### PR TITLE
Fix panic on short outputs

### DIFF
--- a/blake2b/blake2b.go
+++ b/blake2b/blake2b.go
@@ -333,15 +333,14 @@ func (d *Digest) finalize(out []byte) error {
 
 	dCopy.compress()
 
-	// extract output
-	putU64LE(out[0*8:], dCopy.h[0])
-	putU64LE(out[1*8:], dCopy.h[1])
-	putU64LE(out[2*8:], dCopy.h[2])
-	putU64LE(out[3*8:], dCopy.h[3])
-	putU64LE(out[4*8:], dCopy.h[4])
-	putU64LE(out[5*8:], dCopy.h[5])
-	putU64LE(out[6*8:], dCopy.h[6])
-	putU64LE(out[7*8:], dCopy.h[7])
+	var shift uint
+	var mask uint64
+
+	for offset := 0; offset < len(out); offset++ {
+		shift = 8 * (uint(offset) % 8)
+		mask = uint64(0xFF << shift)
+		out[offset] = byte((dCopy.h[offset/8] & mask) >> shift)
+	}
 
 	return nil
 }

--- a/blake2b/blake2b_test.go
+++ b/blake2b/blake2b_test.go
@@ -50,6 +50,7 @@ type ReferenceTestVector struct {
 	Key     string `json:"key"`
 	Persona string `json:"persona,omitempty"`
 	Salt    string `json:"salt,omitempty"`
+	Length  int    `json:"length,omitempty"`
 	Output  string `json:"out"`
 }
 
@@ -125,7 +126,13 @@ func TestExtrasVectors(t *testing.T) {
 		}
 		decodedOutput, _ := hex.DecodeString(test.Output)
 
-		d, err := NewDigest(decodedKey, decodedSalt, decodedPersona, 64)
+		var d *Digest
+
+		if test.Length != 0 {
+			d, err = NewDigest(decodedKey, decodedSalt, decodedPersona, test.Length)
+		} else {
+			d, err = NewDigest(decodedKey, decodedSalt, decodedPersona, 64)
+		}
 		if err != nil {
 			t.Error(err)
 			continue

--- a/blake2s/blake2s.go
+++ b/blake2s/blake2s.go
@@ -313,15 +313,14 @@ func (d *Digest) finalize(out []byte) error {
 
 	dCopy.compress()
 
-	// extract output
-	putU32LE(out[0*4:], dCopy.h[0])
-	putU32LE(out[1*4:], dCopy.h[1])
-	putU32LE(out[2*4:], dCopy.h[2])
-	putU32LE(out[3*4:], dCopy.h[3])
-	putU32LE(out[4*4:], dCopy.h[4])
-	putU32LE(out[5*4:], dCopy.h[5])
-	putU32LE(out[6*4:], dCopy.h[6])
-	putU32LE(out[7*4:], dCopy.h[7])
+	var shift uint
+	var mask uint32
+
+	for offset := 0; offset < len(out); offset++ {
+		shift = 8 * (uint(offset) % 4)
+		mask = uint32(0xFF << shift)
+		out[offset] = byte((dCopy.h[offset/4] & mask) >> shift)
+	}
 
 	return nil
 }

--- a/blake2s/blake2s_test.go
+++ b/blake2s/blake2s_test.go
@@ -36,10 +36,21 @@ func TestParameterBlockInit(t *testing.T) {
 }
 
 func TestNewDigest(t *testing.T) {
-	_, err := NewDigest(nil, nil, nil, 32)
+	digest32, err := NewDigest(nil, nil, nil, 32)
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	digest32.Write(emptyBuf[:16])
+	_ = digest32.Sum(nil)
+
+	digest16, err := NewDigest(nil, nil, nil, 16)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	digest16.Write(emptyBuf[:16])
+	_ = digest16.Sum(nil)
 }
 
 // These come from the BLAKE2s reference implementation.

--- a/gen_vectors.py
+++ b/gen_vectors.py
@@ -33,7 +33,22 @@ def write_blake2s_tests(output_fn):
                 "salt": "",
                 "out": blake2s(key=key_bytes, person=persona_bytes).hexdigest()
                }
-        fd.write(json.dumps(test, indent=True)+(',' if i<7 else '')+'\n')
+        fd.write(json.dumps(test, indent=True)+',\n')
+
+    for i in range(32):
+        salt_bytes = bytearray(range(8))
+        persona_bytes = bytearray(range(8))
+        length = i+1
+        test = {
+                "hash": "blake2s",
+                "in": "",
+                "key": "",
+                "persona": "",
+                "salt": "",
+                "length": length,
+                "out": blake2s(digest_size=length).hexdigest(),
+               }
+        fd.write(json.dumps(test, indent=True)+(',' if i<31 else '')+'\n')
 
     fd.write(']')
     fd.close()

--- a/gen_vectors.py
+++ b/gen_vectors.py
@@ -36,8 +36,6 @@ def write_blake2s_tests(output_fn):
         fd.write(json.dumps(test, indent=True)+',\n')
 
     for i in range(32):
-        salt_bytes = bytearray(range(8))
-        persona_bytes = bytearray(range(8))
         length = i+1
         test = {
                 "hash": "blake2s",
@@ -81,9 +79,22 @@ def write_blake2b_tests(output_fn):
                 "salt": "",
                 "out": blake2b(key=key_bytes, person=persona_bytes).hexdigest()
                }
-        fd.write(json.dumps(test, indent=True)+(',' if i<7 else '')+'\n')
+        fd.write(json.dumps(test, indent=True)+',\n')
 
-    fd.write(']')
+    for i in range(64):
+        length = i+1
+        test = {
+                "hash": "blake2b",
+                "in": "",
+                "key": "",
+                "persona": "",
+                "salt": "",
+                "length": length,
+                "out": blake2b(digest_size=length).hexdigest(),
+               }
+        fd.write(json.dumps(test, indent=True)+(',' if i<63 else '')+'\n')
+
+    fd.write(']\n')
     fd.close()
 
 if __name__ == "__main__":

--- a/testdata/blake2b-extras.json
+++ b/testdata/blake2b-extras.json
@@ -126,5 +126,581 @@
  "persona": "0001020304050607",
  "salt": "",
  "out": "4df7872c83ba634009d5d2d813446a76feb0c332d4a5c565558a2eae314da0d57cc2304dc5baa716b1fcace87ef70cb4ebb38cbf3cfe2e56a394804b7388ad68"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 1,
+ "out": "2e"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 2,
+ "out": "b1fe"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 3,
+ "out": "cec7ea"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 4,
+ "out": "1271cf25"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 5,
+ "out": "7d64c5272e"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 6,
+ "out": "ddd9c40767f9"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 7,
+ "out": "4e9b03474eda9a"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 8,
+ "out": "e4a6a0577479b2b4"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 9,
+ "out": "d6bd6fc9a3324e5f32"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 10,
+ "out": "6fa1d8fcfd719046d762"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 11,
+ "out": "eb6ec15daf9546254f0809"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 12,
+ "out": "b8e1dda3ac0aa3820ad2990b"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 13,
+ "out": "50b4dc6f148a3f25b974e5c829"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 14,
+ "out": "4b1f3c22056a5cf9a3300407d264"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 15,
+ "out": "b7db87196c483405e40f8401fa1fc9"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 16,
+ "out": "cae66941d9efbd404e4d88758ea67670"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 17,
+ "out": "246c0442cd564aced8145b8b60f1370aa7"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 18,
+ "out": "91a1a481a82eb3f3e6262de11f142d234945"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 19,
+ "out": "35bd4214446fda5ce2e05015f1ba43e26f1b96"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 20,
+ "out": "3345524abf6bbe1809449224b5972c41790b6cf2"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 21,
+ "out": "077d8272052a6edfff4047461c3a2b3d9d330dbbf0"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 22,
+ "out": "1065c75a5ab372acff0b521808a4766c70b12b10ad8c"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 23,
+ "out": "e30b37bb45ad2f1954a0ab31666f909df8d4eabd6933e9"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 24,
+ "out": "ab3b5331a7135ed50d0f182d026e60abdb3646fd51bcf8a3"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 25,
+ "out": "94165bbe7a8a0f49fad8c1b39c40b7dd613409378dcc47681f"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 26,
+ "out": "7895f50fee886d460f321601da8d2db483a08c0264cd8ff3617e"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 27,
+ "out": "b41793f77a58236ee36d36570bcd14cf00ba6a443c6c5bd4bb9eaf"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 28,
+ "out": "836cc68931c2e4e3e838602eca1902591d216837bafddfe6f0c8cb07"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 29,
+ "out": "a10eae68c06d70c597699d656d6ae213430569f9c62e04cd2fc3a0c1bf"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 30,
+ "out": "a5d6d5975d09c76462b3f9c74f9568d9f9fd46dfbdcbf3f14bc835298b22"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 31,
+ "out": "b4d7d8f500d546e71fe03f080b6bfefd567a0aa97e84bdb2cf8b15d1867c00"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 32,
+ "out": "0e5751c026e543b2e8ab2eb06099daa1d1e5df47778f7787faab45cdf12fe3a8"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 33,
+ "out": "ddca500c4d28f7f2816de1574f840e4878c1c5aa30c149745e0149273b214c359d"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 34,
+ "out": "90933ab63c7665e2bd6431e496ec60d38839fbec78e33aae2c152c073f64264bdab9"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 35,
+ "out": "148833bb2bfcc18b9e90024eaeecc0a96027a777761e0b9c93d6642937bb4b8705e218"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 36,
+ "out": "92f3592c601fe36aa32c62e305f965905a2982dee6a45c09011ddf05f9cf9b7b5609414f"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 37,
+ "out": "6d82c523a958c2b00e42701be980963438d5f40572c70d3d723c03ddebdb74575866f3adbb"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 38,
+ "out": "dc5abbc8c533139ba5873c9562868914e501b13aadc59c143d1bfe97cbcb5fab5b65ed488158"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 39,
+ "out": "61a54c550005791e4726043fbfc347bb8952e520818157aeaf0d0f877c51950e06ff3157d02a6f"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 40,
+ "out": "2e316d2c76c9760df1e604e4ffd1aa5ac6c6ac50aaa8071f7313ea931e205da084bbae9a2019f6aa"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 41,
+ "out": "592c90e91f3187c352649476b86bba76c128433e6f3ac8c75710042f4b310e1c7aea39b0aff9b51bd3"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 42,
+ "out": "f564703984efb278dfb04536d0bf4b86a17e8a9847104f773b81835ffc60b343a364e224e36552728dd6"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 43,
+ "out": "5112353efd2617941caf7de611f152ac7b6fbacfb682aa43ecb707c8977ae8f307e50da1942c6eed777082"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 44,
+ "out": "b2e01f2639b7e74abab0bb7e88f7ab7ae94ba6292c3a42537ca288635259a50edd9c7d7a1c7b8d2e2f86848e"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 45,
+ "out": "fa9d9e37d6fe09eb8116510fadb9c61cc59e332d46cc4a365e72edc733188f08be9c0894b6dbb06023ff312506"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 46,
+ "out": "d47deb78c6d8db06e3b38d8faa368d22cbab03cbfb2b3ad201be5729ab454278007f76dcdb14de4eb38958745f77"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 47,
+ "out": "e4ac268b5be19d515b8ddd90bc7e89100f875fa994517409907cb6f3c6eefacc3890c84dd3e91cd2886eb57033c749"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 48,
+ "out": "b32811423377f52d7862286ee1a72ee540524380fda1724a6f25d7978c6fd3244a6caf0498812673c5e05ef583825100"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 49,
+ "out": "a993b7c6dbd66f7a45487707d7e3eda19201f7fec9dcf1ae3c0a66eb4be4d21ed8af10490cef0c3168e9ff0dcfb5dcd651"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 50,
+ "out": "3189e5764c09a2f5d1d9f5cb1967ebd3dfeade9c62af8bb0dc032bb3e90dd1e760fbaba8956f97c7602d0a2ec162169ef219"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 51,
+ "out": "31635ed8064b99e056ed7009905673c986944a718c6e5935e7eeb67652550d56fe7ec110a383ef94ef7977be456a44503434ad"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 52,
+ "out": "f4e2de2be49787b13e0b38c0d02578b78a76f6c8fc48948c00f67812bd6c9ceaff17b04617532862be3cb251524b93d83a266e35"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 53,
+ "out": "e3af5d079bce8fbbad6f5047d77025b8e100d91ecc066fa525d290ef6a867f93b2798769067f8790df954682011617a68d7169ef15"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 54,
+ "out": "0668149330f455fe58c70d209cff452742cc1125eee5e1d67af18e9b2a67b5ca6973940135341c2807c9237295ec0a0d173dbc28f687"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 55,
+ "out": "89c4f154fddb635864729c086c40ff2e574ef4fa1ab592d9bee584693852cfeee57c743b9a8771443e522f454218b260838c0a913d29e5"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 56,
+ "out": "e7d2cb731e704ab61a3fa0ddd3bb3a6bfe3c3bc03b2c80a7545a0c9cedb575dfaa6821be9879e9ecd24350297f14470ad3d1cd2d19f27fbf"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 57,
+ "out": "a6e2604d330fa35f9f97cb89a4160928704e058f1aa0badc51b6e16afa943362fc1b32a4d79138b8103dfcad3239de59c17a267e72f7a0693e"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 58,
+ "out": "f3cc91641a39f6acada71544227505ae109b8c86c2f5fc3c4b7265c64ca6e99967824cea78f6ffb9a0851c86aa52b28ba3352164eedfefc80ddd"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 59,
+ "out": "cf1335ff92a6710c3cfa3dd8ac8c7a435aece775997bdaa1ac57276b0fa16b9a5f1f78a334eefafd0bc9d9cafa6633ba7abed8f67ce8d287af1822"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 60,
+ "out": "22f194f655ea58d7fefe35b09c91c91cf5e1a4047181ea7cd7674e597be65f6541fa1fdddf404e7851b1d471478048d550546d14d88345fb422c19f6"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 61,
+ "out": "d10c86444347b9bbb839717bc3161a10412c52fd2eb52c0a08fcd4c1f091801c0b2b09c74d716f4874761ec1b11afd66be0e13b129b6bc877720f2c7fd"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 62,
+ "out": "50e5578cdbe722b76b9b7d629aec8fb4926b4073da62774e64cafa1b33627c24d70009660e784558b3daa7a65b6841976c41cf3d6891ea1ccdd10894e64d"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 63,
+ "out": "4ded8c5fc8b12f3273f877ca585a44ad6503249a2b345d6d9c0e67d85bcb700db4178c0303e93b8f4ad758b8e2c9fd8b3d0c28e585f1928334bb77d36782e8"
+},
+{
+ "hash": "blake2b",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 64,
+ "out": "786a02f742015903c6c6fd852552d272912f4740e15847618a86e217f71f5419d25e1031afee585313896444934eb04b903a685b1448b755d56f701afe9be2ce"
 }
 ]

--- a/testdata/blake2s-extras.json
+++ b/testdata/blake2s-extras.json
@@ -126,5 +126,293 @@
  "persona": "0001020304050607",
  "salt": "",
  "out": "e397cdd76bc45ef9d3d36ca2db13a6631b12c05909bbdf73ebb1761ee0944821"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 1,
+ "out": "a1"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 2,
+ "out": "8f38"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 3,
+ "out": "ad25c7"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 4,
+ "out": "36e9d246"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 5,
+ "out": "0c58705f4f"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 6,
+ "out": "ef6e31b489af"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 7,
+ "out": "de1931c0881609"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 8,
+ "out": "ef2a8b78dd80da9c"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 9,
+ "out": "ab1d1d2e423e803924"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 10,
+ "out": "1bf21a98c78a1c376ae9"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 11,
+ "out": "567004bf96e4a25773ebf4"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 12,
+ "out": "a10486e873ac3dcef45bbba2"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 13,
+ "out": "758fe2c70fa22afd145e08c8c1"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 14,
+ "out": "80b1192a5cd72ee97b703b91616b"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 15,
+ "out": "89d14662cd5728a3b60c6240c99a62"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 16,
+ "out": "64550d6ffe2c0a01a14aba1eade0200c"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 17,
+ "out": "20ec13a2883f05fd6507dbfd3874db7cba"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 18,
+ "out": "81ac86b9e6a116711f1424875720a2121378"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 19,
+ "out": "d2e2d7deca16f2f6b2960de81ac5547fad2c7f"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 20,
+ "out": "354c9c33f735962418bdacb9479873429c34916f"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 21,
+ "out": "dc2ea42df9976a83adfbf854f30051b68e7115a753"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 22,
+ "out": "c3296897bb43ce9211a9121cf1767b34b8d9349fb06b"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 23,
+ "out": "c3aa6d758b7019fdea61f4fad3a4338bf378b2d32bff7c"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 24,
+ "out": "a847d26c2f966c5c4cc222b174918a56037cdee34b3f872f"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 25,
+ "out": "8ac6416804b719c221366263abdda861ec19ebb2f8f75dd4ea"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 26,
+ "out": "e90af5ca5d02f36adec62d0588ab5dc21c81e91cde3e6cd36aad"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 27,
+ "out": "dae10354a41d7b16066966d565e4d063ef5a9de5ac4f9583ed4961"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 28,
+ "out": "1fa1291e65248b37b3433475b2a0dd63d54a11ecc4e3e034e7bc1ef4"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 29,
+ "out": "9965fe1085a8d2294d96b40a6494ea1b8367551d69ea07188b2598967e"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 30,
+ "out": "526f4a3a959bd5d1665241f94c619dbb367250c3bdcfeb3b29737b6ea44d"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 31,
+ "out": "1f57c56334f1ba2d62275430fdc2d2301017ba6be19864dac5a5eca012da4d"
+},
+{
+ "hash": "blake2s",
+ "in": "",
+ "key": "",
+ "persona": "",
+ "salt": "",
+ "length": 32,
+ "out": "69217a3079908094e11121d042354a7c1f55b6482ca1a51e1b250dfd1ed0eef9"
 }
 ]


### PR DESCRIPTION
Previously, we tried to write a full-sized output regardless of what was asked for. Now we write only as many bytes as requested.

Closes https://github.com/gtank/blake2/issues/1