### PR TITLE
Attempt #2: always allocate for the maximum possible digest output

### DIFF
--- a/blake2b/blake2b.go
+++ b/blake2b/blake2b.go
@@ -333,14 +333,15 @@ func (d *Digest) finalize(out []byte) error {
 
 	dCopy.compress()
 
-	var shift uint
-	var mask uint64
-
-	for offset := 0; offset < len(out); offset++ {
-		shift = 8 * (uint(offset) % 8)
-		mask = uint64(0xFF << shift)
-		out[offset] = byte((dCopy.h[offset/8] & mask) >> shift)
-	}
+	// extract output
+	putU64LE(out[0*8:], dCopy.h[0])
+	putU64LE(out[1*8:], dCopy.h[1])
+	putU64LE(out[2*8:], dCopy.h[2])
+	putU64LE(out[3*8:], dCopy.h[3])
+	putU64LE(out[4*8:], dCopy.h[4])
+	putU64LE(out[5*8:], dCopy.h[5])
+	putU64LE(out[6*8:], dCopy.h[6])
+	putU64LE(out[7*8:], dCopy.h[7])
 
 	return nil
 }
@@ -442,7 +443,7 @@ func (d *Digest) Write(input []byte) (n int, err error) {
 // It does not change the underlying hash state.
 func (d *Digest) Sum(b []byte) (out []byte) {
 	// if there's space, reuse the b slice
-	if n := len(b) + d.size; cap(b) >= n {
+	if n := len(b) + 64; cap(b) >= n {
 		out = b[:n]
 	} else {
 		out = make([]byte, n)
@@ -455,7 +456,7 @@ func (d *Digest) Sum(b []byte) (out []byte) {
 		return out[:len(b)]
 	}
 
-	return out
+	return out[:len(b)+d.size]
 }
 
 // Reset resets the Hash to its initial state.

--- a/blake2s/blake2s.go
+++ b/blake2s/blake2s.go
@@ -313,14 +313,14 @@ func (d *Digest) finalize(out []byte) error {
 
 	dCopy.compress()
 
-	var shift uint
-	var mask uint32
-
-	for offset := 0; offset < len(out); offset++ {
-		shift = 8 * (uint(offset) % 4)
-		mask = uint32(0xFF << shift)
-		out[offset] = byte((dCopy.h[offset/4] & mask) >> shift)
-	}
+	putU32LE(out[0*4:], dCopy.h[0])
+	putU32LE(out[1*4:], dCopy.h[1])
+	putU32LE(out[2*4:], dCopy.h[2])
+	putU32LE(out[3*4:], dCopy.h[3])
+	putU32LE(out[4*4:], dCopy.h[4])
+	putU32LE(out[5*4:], dCopy.h[5])
+	putU32LE(out[6*4:], dCopy.h[6])
+	putU32LE(out[7*4:], dCopy.h[7])
 
 	return nil
 }
@@ -423,7 +423,7 @@ func (d *Digest) Write(input []byte) (n int, err error) {
 // It does not change the underlying hash state.
 func (d *Digest) Sum(b []byte) (out []byte) {
 	// if there's space, reuse the b slice
-	if n := len(b) + d.size; cap(b) >= n {
+	if n := len(b) + 32; cap(b) >= n {
 		out = b[:n]
 	} else {
 		out = make([]byte, n)
@@ -436,7 +436,7 @@ func (d *Digest) Sum(b []byte) (out []byte) {
 		return out[:len(b)]
 	}
 
-	return out
+	return out[:len(b)+d.size]
 }
 
 // Reset resets the Hash to its initial state.


### PR DESCRIPTION
This alternative approach notably improves the performance on small input tasks (like hashing 32-byte keys or group elements), mitigating most of the penalty of the earlier fix at the cost of unintuitive allocation behavior.

cpu: Intel(R) Core(TM) i7-7560U CPU @ 2.40GHz
go version devel +b0f01e17f8 Wed Dec 16 22:45:19 2020 +0000 linux/amd64

blake2s:
```
name          old time/op    new time/op    delta
Hash8Bytes-4     345ns ± 2%     293ns ± 1%  -15.07%  (p=0.000 n=10+9)
Hash1K-4        2.81µs ± 0%    2.76µs ± 1%   -1.86%  (p=0.000 n=8+9)
Hash8K-4        20.7µs ± 1%    20.5µs ± 1%   -1.02%  (p=0.000 n=9+9)

name          old speed      new speed      delta
Hash8Bytes-4  23.2MB/s ± 2%  27.3MB/s ± 1%  +17.74%  (p=0.000 n=10+9)
Hash1K-4       364MB/s ± 0%   371MB/s ± 1%   +1.90%  (p=0.000 n=8+9)
Hash8K-4       396MB/s ± 1%   400MB/s ± 1%   +1.03%  (p=0.000 n=9+9)
```
blake2b:
```
name          old time/op    new time/op    delta
Hash8Bytes-4     459ns ± 1%     366ns ± 1%  -20.40%  (p=0.000 n=10+10)
Hash1K-4        1.87µs ± 0%    1.79µs ± 0%   -4.36%  (p=0.000 n=10+10)
Hash8K-4        13.0µs ± 1%    13.0µs ± 0%     ~     (p=0.113 n=10+9)

name          old speed      new speed      delta
Hash8Bytes-4  17.4MB/s ± 1%  21.9MB/s ± 1%  +25.62%  (p=0.000 n=10+10)
Hash1K-4       547MB/s ± 0%   572MB/s ± 0%   +4.55%  (p=0.000 n=10+10)
Hash8K-4       629MB/s ± 1%   628MB/s ± 0%     ~     (p=0.113 n=10+9)
```

cc @elichai @filosottile for thoughts on if this is "better" than the prior approach